### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/github3/utils.py
+++ b/github3/utils.py
@@ -42,7 +42,7 @@ def timestamp_parameter(timestamp, allow_none=True):
                               " formatted date") % timestamp)
         return timestamp
 
-    raise ValueError("Cannot accept type %s for timestamp" % type(timestamp))
+    raise ValueError("Cannot accept type {0!s} for timestamp".format(type(timestamp)))
 
 
 class UTC(datetime.tzinfo):

--- a/tests/unit/test_repos_release.py
+++ b/tests/unit/test_repos_release.py
@@ -68,7 +68,7 @@ class TestRelease(UnitHelper):
                 'text/plain', 'test_repos_release.py', content,
             )
             self.post_called_with(
-                url_for('/1/assets?name=%s' % 'test_repos_release.py'),
+                url_for('/1/assets?name={0!s}'.format('test_repos_release.py')),
                 data=content,
                 headers={
                     'Content-Type': 'text/plain'
@@ -84,7 +84,7 @@ class TestRelease(UnitHelper):
                 'text/plain', 'test_repos_release.py', content, 'test-label'
             )
             self.post_called_with(
-                url_for('/1/assets?name=%s&label=%s' % (
+                url_for('/1/assets?name={0!s}&label={1!s}'.format(
                     'test_repos_release.py', 'test-label')),
                 data=content,
                 headers={


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:github3.py?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:github3.py?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
